### PR TITLE
Align mobile email with legally-compliant petition format

### DIFF
--- a/app/issues/[id]/index.tsx
+++ b/app/issues/[id]/index.tsx
@@ -17,6 +17,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AuthorityCard } from '@/components/authority-card';
 import { CommentInputBar } from '@/components/comment-input-bar';
 import { CommentItem } from '@/components/comment-item';
+import { EmailInstructionsSheet, type EmailInstructionsSheetRef } from '@/components/email-instructions-sheet';
 import { EmailPrompt } from '@/components/email-prompt';
 import { ErrorState } from '@/components/error-state';
 import { LocationPreview } from '@/components/location-preview';
@@ -37,7 +38,6 @@ import { useBlockUser } from '@/hooks/use-blocked-users';
 import { useComments, useUpdateComment } from '@/hooks/use-comments';
 import { useEmailTracking } from '@/hooks/use-email-tracking';
 import { useIssueDetail } from '@/hooks/use-issue-detail';
-import { useProfile } from '@/hooks/use-profile';
 import { showReportError, useReportComment, useReportIssue } from '@/hooks/use-report';
 import { useThemeColor } from '@/hooks/use-theme-color';
 import { useAuth } from '@/store/auth-context';
@@ -487,7 +487,6 @@ export default function IssueDetailScreen() {
 
   const { requireAuth, user } = useAuth();
   const { data: issue, isLoading, isError, error, refetch } = useIssueDetail(id);
-  const { data: profile } = useProfile();
   const { mutate: trackEmailSent } = useEmailTracking(id);
   const { mutate: updateCommentFn, isPending: isEditSaving } = useUpdateComment(id);
   const { mutate: reportIssueFn, isPending: isReportingIssue } = useReportIssue();
@@ -646,6 +645,7 @@ export default function IssueDetailScreen() {
 
   // Email flow state
   const emailPromptRef = useRef<BottomSheetMethods>(null);
+  const emailInstructionsRef = useRef<EmailInstructionsSheetRef>(null);
   const emailFlowActiveRef = useRef(false);
 
   // Detect return from email client via AppState
@@ -704,25 +704,26 @@ export default function IssueDetailScreen() {
         const { to, subject, body } = buildEmailParts({
           authority,
           issue,
-          userName: profile?.displayName ?? null,
         });
-        openComposer({
-          to,
-          subject,
-          body,
-          title: Localization.email.chooseApp,
-          cancelLabel: Localization.actions.cancel,
-        })
-          .then(() => {
-            emailFlowActiveRef.current = true;
+        emailInstructionsRef.current?.open(() => {
+          openComposer({
+            to,
+            subject,
+            body,
+            title: Localization.email.chooseApp,
+            cancelLabel: Localization.actions.cancel,
           })
-          .catch((err) => {
-            console.warn('[email] Failed to open email composer for issue', issue.id, err);
-            Alert.alert(Localization.email.openFailed);
-          });
+            .then(() => {
+              emailFlowActiveRef.current = true;
+            })
+            .catch((err) => {
+              console.warn('[email] Failed to open email composer for issue', issue.id, err);
+              Alert.alert(Localization.email.openFailed);
+            });
+        });
       });
     },
-    [issue, requireAuth, profile?.displayName],
+    [issue, requireAuth],
   );
 
   // Bottom bar CTA: single authority → send directly, multiple → scroll to section
@@ -874,7 +875,10 @@ export default function IssueDetailScreen() {
         onReplySuccess={handleReplySuccess}
       />
 
-      {/* Email Confirmation Prompt */}
+      {/* Email Instructions — shown before opening composer */}
+      <EmailInstructionsSheet ref={emailInstructionsRef} />
+
+      {/* Email Confirmation Prompt — shown after return from email app */}
       <EmailPrompt
         ref={emailPromptRef}
         onConfirm={handleEmailConfirm}

--- a/components/email-instructions-sheet.tsx
+++ b/components/email-instructions-sheet.tsx
@@ -1,0 +1,85 @@
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { ThemedText } from '@/components/themed-text';
+import { Button } from '@/components/ui/button';
+import {
+  ThemedBottomSheet,
+  type BottomSheetMethods,
+} from '@/components/ui/bottom-sheet';
+import { Localization } from '@/constants/localization';
+import { Spacing } from '@/constants/spacing';
+import { useThemeColor } from '@/hooks/use-theme-color';
+
+const SNAP_POINTS = ['55%'];
+
+export type EmailInstructionsSheetRef = {
+  open: (onContinue: () => void) => void;
+  close: () => void;
+};
+
+export const EmailInstructionsSheet = forwardRef<EmailInstructionsSheetRef>(
+  function EmailInstructionsSheet(_props, ref) {
+    const sheetRef = useRef<BottomSheetMethods>(null);
+    const onContinueRef = useRef<(() => void) | null>(null);
+    const textSecondary = useThemeColor({}, 'textSecondary');
+
+    useImperativeHandle(ref, () => ({
+      open: (onContinue: () => void) => {
+        onContinueRef.current = onContinue;
+        sheetRef.current?.snapToIndex(0);
+      },
+      close: () => {
+        sheetRef.current?.close();
+      },
+    }));
+
+    const handleContinue = useCallback(() => {
+      sheetRef.current?.close();
+      onContinueRef.current?.();
+    }, []);
+
+    return (
+      <ThemedBottomSheet ref={sheetRef} snapPoints={SNAP_POINTS}>
+        <View style={styles.content}>
+          <ThemedText type="h3">{Localization.email.instructionsTitle}</ThemedText>
+
+          <ThemedText type="body">{Localization.email.instructionsBody}</ThemedText>
+
+          <View style={styles.placeholders}>
+            {Localization.email.instructionsPlaceholders.map((item) => (
+              <ThemedText key={item} type="caption" style={{ color: textSecondary }}>
+                {item}
+              </ThemedText>
+            ))}
+          </View>
+
+          <ThemedText type="caption" style={{ color: textSecondary }}>
+            {Localization.email.instructionsNote}
+          </ThemedText>
+
+          <Button
+            title={Localization.email.instructionsContinue}
+            variant="primary"
+            onPress={handleContinue}
+            style={styles.button}
+          />
+        </View>
+      </ThemedBottomSheet>
+    );
+  },
+);
+
+const styles = StyleSheet.create({
+  content: {
+    padding: Spacing.lg,
+    gap: Spacing.md,
+  },
+  placeholders: {
+    gap: Spacing.xs,
+  },
+  button: {
+    width: '100%',
+    marginTop: Spacing.sm,
+  },
+});

--- a/components/email-instructions-sheet.tsx
+++ b/components/email-instructions-sheet.tsx
@@ -22,11 +22,13 @@ export const EmailInstructionsSheet = forwardRef<EmailInstructionsSheetRef>(
   function EmailInstructionsSheet(_props, ref) {
     const sheetRef = useRef<BottomSheetMethods>(null);
     const onContinueRef = useRef<(() => void) | null>(null);
+    const pendingContinueRef = useRef(false);
     const textSecondary = useThemeColor({}, 'textSecondary');
 
     useImperativeHandle(ref, () => ({
       open: (onContinue: () => void) => {
         onContinueRef.current = onContinue;
+        pendingContinueRef.current = false;
         sheetRef.current?.snapToIndex(0);
       },
       close: () => {
@@ -35,12 +37,19 @@ export const EmailInstructionsSheet = forwardRef<EmailInstructionsSheetRef>(
     }));
 
     const handleContinue = useCallback(() => {
+      pendingContinueRef.current = true;
       sheetRef.current?.close();
-      onContinueRef.current?.();
+    }, []);
+
+    const handleSheetChange = useCallback((index: number) => {
+      if (index === -1 && pendingContinueRef.current) {
+        pendingContinueRef.current = false;
+        onContinueRef.current?.();
+      }
     }, []);
 
     return (
-      <ThemedBottomSheet ref={sheetRef} snapPoints={SNAP_POINTS}>
+      <ThemedBottomSheet ref={sheetRef} snapPoints={SNAP_POINTS} onChange={handleSheetChange}>
         <View style={styles.content}>
           <ThemedText type="h3">{Localization.email.instructionsTitle}</ThemedText>
 

--- a/constants/localization.ts
+++ b/constants/localization.ts
@@ -213,6 +213,19 @@ export const Localization = {
     sentSuccess: 'Email confirmat! +10 puncte',
     openFailed: 'Nu s-a putut deschide aplicația de email',
     chooseApp: 'Alege aplicația de email',
+    instructionsTitle: 'Instrucțiuni importante',
+    instructionsBody:
+      'Emailul conține câmpuri marcate cu [ ] pe care trebuie să le completezi cu datele tale personale înainte de trimitere.',
+    instructionsPlaceholders: [
+      '[NUMELE TĂU COMPLET] → numele tău legal complet',
+      '[CNP-UL TĂU] → codul numeric personal',
+      '[ADRESA TA DE DOMICILIU] → adresa completă',
+      '[ADRESA TA DE EMAIL] → emailul tău',
+      '[NUMĂRUL TĂU DE TELEFON] → telefonul tău',
+    ] as readonly string[],
+    instructionsNote:
+      'Conform OG 27/2002, petiția trebuie să conțină datele tale de identificare pentru a fi luată în considerare.',
+    instructionsContinue: 'Am înțeles, deschide emailul',
   },
 
   // Authority

--- a/constants/localization.ts
+++ b/constants/localization.ts
@@ -226,6 +226,29 @@ export const Localization = {
     instructionsNote:
       'Conform OG 27/2002, petiția trebuie să conțină datele tale de identificare pentru a fi luată în considerare.',
     instructionsContinue: 'Am înțeles, deschide emailul',
+    // Petition template strings (OG 27/2002)
+    petition: {
+      subjectTemplate: (title: string) =>
+        `Petiție - [NUMELE TĂU COMPLET] - ${title}`,
+      salutation: (authorityName: string) => `Către: ${authorityName}`,
+      petitionerLine:
+        'Subsemnatul/a [NUMELE TĂU COMPLET], CNP: [CNP-UL TĂU], domiciliat(ă) în [ADRESA TA DE DOMICILIU], email: [ADRESA TA DE EMAIL], telefon: [NUMĂRUL TĂU DE TELEFON], vă adresez prezenta petiție prin care solicit să luați măsuri în legătură cu următoarea problemă:',
+      locationLabel: 'Locație:',
+      dateLabel: 'Data sesizării:',
+      locationFallback: 'Locație nespecificată',
+      authorityFallback: 'Autoritate',
+      defaultDesiredOutcome:
+        'Vă solicit să luați măsurile necesare pentru remedierea acestei probleme în cel mai scurt timp posibil.',
+      photosAttachment: (count: number) =>
+        `La prezenta petiție anexez ${count} ${count === 1 ? 'fotografie care documentează' : 'fotografii care documentează'} problema semnalată.`,
+      linkPrefix: 'Link către documentația completă:',
+      legalParagraph:
+        'Conform O.G. 27/2002 privind reglementarea activității de soluționare a petițiilor, vă rog să îmi comunicați răspunsul la adresa de domiciliu menționată mai sus sau prin email la [ADRESA TA DE EMAIL], în termenul legal de 30 de zile.',
+      registrationRequest:
+        'De asemenea, vă rog să îmi comunicați numărul de înregistrare al acestei petiții pe adresa de email menționată mai sus, pentru a putea urmări soluționarea acesteia.',
+      closing: 'Cu stimă,',
+      namePlaceholder: '[NUMELE TĂU COMPLET]',
+    },
   },
 
   // Authority

--- a/utils/build-mailto.ts
+++ b/utils/build-mailto.ts
@@ -1,10 +1,9 @@
-import { Localization } from '@/constants/localization';
 import type { IssueAuthorityResponse, IssueDetailResponse } from '@/types/issues';
+import { formatDateRomanian } from '@/utils/format-date-romanian';
 
 type BuildMailtoParams = {
   authority: IssueAuthorityResponse;
   issue: IssueDetailResponse;
-  userName: string | null;
 };
 
 export type EmailParts = {
@@ -13,66 +12,60 @@ export type EmailParts = {
   body: string;
 };
 
-export function buildEmailParts({ authority, issue, userName }: BuildMailtoParams): EmailParts {
+/**
+ * Build a legally-compliant petition email per Romanian OG 27/2002.
+ * Contains placeholder brackets the user must fill in their email client.
+ */
+export function buildEmailParts({ authority, issue }: BuildMailtoParams): EmailParts {
   const to = authority.email ?? '';
-  const district = issue.district ?? 'București';
 
-  const subject = `[URGENT] Sesizare cetățenească - ${issue.title ?? ''} - ${district}, București`;
+  const subject = `Petiție - [NUMELE TĂU COMPLET] - ${issue.title ?? ''}`;
 
-  const categoryLabel =
-    Localization.category[issue.category as keyof typeof Localization.category] ?? issue.category;
-  const urgencyLabel =
-    Localization.urgency[issue.urgency as keyof typeof Localization.urgency] ?? issue.urgency;
+  const locationParts = [issue.address];
+  if (issue.district) locationParts.push(issue.district);
+  const locationString = locationParts.filter(Boolean).join(', ') || 'Locație nespecificată';
 
-  const lines: string[] = [
-    `Stimată ${authority.name ?? 'autoritate'},`,
-    '',
-    'Vă scriu pentru a vă aduce la cunoștință o problemă comunitară care necesită atenția dumneavoastră.',
-    '',
-    'Detalii problemă:',
-    `- Titlu: ${issue.title ?? ''}`,
-    `- Locație: ${issue.address ?? ''}`,
-    `- Categorie: ${categoryLabel}`,
-    `- Urgență: ${urgencyLabel}`,
-    '',
-    'Descriere:',
-    issue.description ?? '',
-  ];
+  const createdDate = formatDateRomanian(issue.createdAt);
+  const currentDate = formatDateRomanian(new Date().toISOString());
 
-  if (issue.desiredOutcome) {
-    lines.push('', 'Rezultat dorit:', issue.desiredOutcome);
-  }
+  const communityImpactSection = issue.communityImpact?.trim()
+    ? `\n${issue.communityImpact.trim()}`
+    : '';
 
-  if (issue.communityImpact) {
-    lines.push('', 'Impact asupra comunității:', issue.communityImpact);
-  }
+  const desiredOutcomeText = issue.desiredOutcome?.trim()
+    ? issue.desiredOutcome.trim()
+    : 'Vă solicit să luați măsurile necesare pentru remedierea acestei probleme în cel mai scurt timp posibil.';
 
-  const parsedDate = new Date(issue.createdAt);
-  const createdDate = Number.isNaN(parsedDate.getTime())
-    ? issue.createdAt
-    : parsedDate.toLocaleDateString('ro-RO');
+  const photoCount = issue.photos?.length ?? 0;
+  const photosSection =
+    photoCount > 0
+      ? `La prezenta petiție anexez ${photoCount} ${photoCount === 1 ? 'fotografie care documentează' : 'fotografii care documentează'} problema semnalată.\n`
+      : '';
 
-  lines.push(
-    '',
-    `Această problemă a fost raportată pe ${createdDate}${issue.emailsSent > 0 ? ` și a fost deja semnalată de ${issue.emailsSent} cetățeni` : ''}.`,
-    '',
-    'Vă rog să interveniți pentru rezolvarea acestei situații.',
-    '',
-    'Cu stimă,',
-    userName ?? 'Un cetățean',
-    '',
-    '---',
-    `Referință: ${issue.id}`,
-    'Trimis prin platforma Civiti',
-  );
+  const authorityName = authority.name ?? 'Autoritate';
 
-  const body = lines.join('\n');
+  const body = `Către: ${authorityName}
+
+Subsemnatul/a [NUMELE TĂU COMPLET], CNP: [CNP-UL TĂU], domiciliat(ă) în [ADRESA TA DE DOMICILIU], email: [ADRESA TA DE EMAIL], telefon: [NUMĂRUL TĂU DE TELEFON], vă adresez prezenta petiție prin care solicit să luați măsuri în legătură cu următoarea problemă:
+
+${issue.title ?? ''}
+
+Locație: ${locationString}
+Data sesizării: ${createdDate}
+
+${issue.description ?? ''}${communityImpactSection}
+
+${desiredOutcomeText}
+
+${photosSection}Link către documentația completă: https://civiti.ro/issues/${issue.id}
+
+Conform O.G. 27/2002 privind reglementarea activității de soluționare a petițiilor, vă rog să îmi comunicați răspunsul la adresa de domiciliu menționată mai sus sau prin email la [ADRESA TA DE EMAIL], în termenul legal de 30 de zile.
+
+De asemenea, vă rog să îmi comunicați numărul de înregistrare al acestei petiții pe adresa de email menționată mai sus, pentru a putea urmări soluționarea acesteia.
+
+Cu stimă,
+[NUMELE TĂU COMPLET]
+${currentDate}`;
 
   return { to, subject, body };
-}
-
-/** @deprecated Use buildEmailParts + openComposer instead */
-export function buildMailto(params: BuildMailtoParams): string {
-  const { to, subject, body } = buildEmailParts(params);
-  return `mailto:${to}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
 }

--- a/utils/build-mailto.ts
+++ b/utils/build-mailto.ts
@@ -1,3 +1,4 @@
+import { Localization } from '@/constants/localization';
 import type { IssueAuthorityResponse, IssueDetailResponse } from '@/types/issues';
 import { formatDateRomanian } from '@/utils/format-date-romanian';
 
@@ -12,6 +13,8 @@ export type EmailParts = {
   body: string;
 };
 
+const { petition } = Localization.email;
+
 /**
  * Build a legally-compliant petition email per Romanian OG 27/2002.
  * Contains placeholder brackets the user must fill in their email client.
@@ -19,11 +22,12 @@ export type EmailParts = {
 export function buildEmailParts({ authority, issue }: BuildMailtoParams): EmailParts {
   const to = authority.email ?? '';
 
-  const subject = `Petiție - [NUMELE TĂU COMPLET] - ${issue.title ?? ''}`;
+  const subject = petition.subjectTemplate(issue.title ?? '');
 
   const locationParts = [issue.address];
   if (issue.district) locationParts.push(issue.district);
-  const locationString = locationParts.filter(Boolean).join(', ') || 'Locație nespecificată';
+  const locationString =
+    locationParts.filter(Boolean).join(', ') || petition.locationFallback;
 
   const createdDate = formatDateRomanian(issue.createdAt);
   const currentDate = formatDateRomanian(new Date().toISOString());
@@ -34,37 +38,35 @@ export function buildEmailParts({ authority, issue }: BuildMailtoParams): EmailP
 
   const desiredOutcomeText = issue.desiredOutcome?.trim()
     ? issue.desiredOutcome.trim()
-    : 'Vă solicit să luați măsurile necesare pentru remedierea acestei probleme în cel mai scurt timp posibil.';
+    : petition.defaultDesiredOutcome;
 
   const photoCount = issue.photos?.length ?? 0;
   const photosSection =
-    photoCount > 0
-      ? `La prezenta petiție anexez ${photoCount} ${photoCount === 1 ? 'fotografie care documentează' : 'fotografii care documentează'} problema semnalată.\n`
-      : '';
+    photoCount > 0 ? `${petition.photosAttachment(photoCount)}\n` : '';
 
-  const authorityName = authority.name ?? 'Autoritate';
+  const authorityName = authority.name ?? petition.authorityFallback;
 
-  const body = `Către: ${authorityName}
+  const body = `${petition.salutation(authorityName)}
 
-Subsemnatul/a [NUMELE TĂU COMPLET], CNP: [CNP-UL TĂU], domiciliat(ă) în [ADRESA TA DE DOMICILIU], email: [ADRESA TA DE EMAIL], telefon: [NUMĂRUL TĂU DE TELEFON], vă adresez prezenta petiție prin care solicit să luați măsuri în legătură cu următoarea problemă:
+${petition.petitionerLine}
 
 ${issue.title ?? ''}
 
-Locație: ${locationString}
-Data sesizării: ${createdDate}
+${petition.locationLabel} ${locationString}
+${petition.dateLabel} ${createdDate}
 
 ${issue.description ?? ''}${communityImpactSection}
 
 ${desiredOutcomeText}
 
-${photosSection}Link către documentația completă: https://civiti.ro/issues/${issue.id}
+${photosSection}${petition.linkPrefix} https://civiti.ro/issues/${issue.id}
 
-Conform O.G. 27/2002 privind reglementarea activității de soluționare a petițiilor, vă rog să îmi comunicați răspunsul la adresa de domiciliu menționată mai sus sau prin email la [ADRESA TA DE EMAIL], în termenul legal de 30 de zile.
+${petition.legalParagraph}
 
-De asemenea, vă rog să îmi comunicați numărul de înregistrare al acestei petiții pe adresa de email menționată mai sus, pentru a putea urmări soluționarea acesteia.
+${petition.registrationRequest}
 
-Cu stimă,
-[NUMELE TĂU COMPLET]
+${petition.closing}
+${petition.namePlaceholder}
 ${currentDate}`;
 
   return { to, subject, body };

--- a/utils/format-date-romanian.ts
+++ b/utils/format-date-romanian.ts
@@ -1,0 +1,11 @@
+/**
+ * Formats an ISO date string as a Romanian date: DD.MM.YYYY
+ */
+export function formatDateRomanian(isoDate: string): string {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) return isoDate;
+  const day = date.getDate().toString().padStart(2, '0');
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const year = date.getFullYear();
+  return `${day}.${month}.${year}`;
+}

--- a/utils/format-date-romanian.ts
+++ b/utils/format-date-romanian.ts
@@ -3,7 +3,7 @@
  */
 export function formatDateRomanian(isoDate: string): string {
   const date = new Date(isoDate);
-  if (Number.isNaN(date.getTime())) return isoDate;
+  if (Number.isNaN(date.getTime())) return '';
   const day = date.getDate().toString().padStart(2, '0');
   const month = (date.getMonth() + 1).toString().padStart(2, '0');
   const year = date.getFullYear();


### PR DESCRIPTION
## Summary
- Replaced the informal email template with a petition format compliant with Romanian OG 27/2002, matching the web app implementation
- Added pre-compose instructions sheet that explains placeholder fields (`[NUMELE TĂU COMPLET]`, `[CNP-UL TĂU]`, etc.) before opening the email client
- New `formatDateRomanian` utility for DD.MM.YYYY date formatting
- Removed deprecated `buildMailto()` function and unused `useProfile` dependency from issue detail

## Test plan
- [ ] Open an issue detail, tap "Trimite Email" on an authority card → instructions bottom sheet appears with placeholder list
- [ ] Tap "Am înțeles, deschide emailul" → email app opens with petition subject (`Petiție - [NUMELE TĂU COMPLET] - ...`) and full legal body
- [ ] Verify `Către:` line shows the authority name (auto-filled)
- [ ] Verify personal data placeholders are present: `[NUMELE TĂU COMPLET]`, `[CNP-UL TĂU]`, `[ADRESA TA DE DOMICILIU]`, `[ADRESA TA DE EMAIL]`, `[NUMĂRUL TĂU DE TELEFON]`
- [ ] Verify OG 27/2002 legal paragraph and registration number request are in the body
- [ ] Verify link to `https://civiti.ro/issues/{id}` is present
- [ ] Return to app → "Ai trimis emailul?" confirmation prompt still works
- [ ] Test with issue that has no photos (no photo line), no desired outcome (default text), no community impact (section omitted)
- [ ] Test on both iOS and Android — verify diacritics render correctly in subject/body

🤖 Generated with [Claude Code](https://claude.com/claude-code)